### PR TITLE
Fix zinglet installation to avoid pulling entire repository

### DIFF
--- a/zing/config.go
+++ b/zing/config.go
@@ -1,9 +1,17 @@
 package zing
 
+import "fmt"
+
 // Placeholder for configuration management.  Could use a struct to hold
 // configuration values (e.g., repository URL).
 
 // For now, we'll hardcode the repository URL.
 func GetRepositoryURL() string {
 	return "https://github.com/SharkStudiosSK/zinglets-repo.git" // Replace with the actual URL
+}
+
+// GetZingletURL returns the URL for a specific zinglet.
+func GetZingletURL(zingletName string) string {
+	baseURL := GetRepositoryURL()
+	return fmt.Sprintf("%s/%s", baseURL, zingletName)
 }

--- a/zing/install.go
+++ b/zing/install.go
@@ -11,15 +11,15 @@ import (
 func Install(zingletName string) error {
 	fmt.Printf("Installing zinglet: %s\n", zingletName)
 
-	// 1. Clone or update the entire zinglets repository.
-	err := CloneOrUpdate(zingletName)
+	// 1. Clone or update the specific zinglet directory.
+	err := CloneOrUpdateZinglet(zingletName)
 	if err != nil {
 		return err
 	}
 
 	// 2. Determine the path to the *zinglet's subdirectory* within the repository.
 	zingHome := os.Getenv("HOME") + "/.zing"
-	repoDir := filepath.Join(zingHome, "zinglets", "zinglets-repo")
+	repoDir := filepath.Join(zingHome, "zinglets")
 	zingletDir := filepath.Join(repoDir, zingletName)
 
 	// 3. Check if the zinglet directory exists within the repository.

--- a/zing/repository.go
+++ b/zing/repository.go
@@ -7,22 +7,22 @@ import (
 	"path/filepath"
 )
 
-// CloneOrUpdate clones or updates the *entire* zinglets repository.
-func CloneOrUpdate(zingletName string) error {
-	repoURL := GetRepositoryURL() // Get the repository URL from config.go
+// CloneOrUpdateZinglet clones or updates the specific zinglet directory.
+func CloneOrUpdateZinglet(zingletName string) error {
+	repoURL := GetZingletURL(zingletName) // Get the specific zinglet URL from config.go
 	zingHome := os.Getenv("HOME") + "/.zing"
-	targetDir := filepath.Join(zingHome, "zinglets", "zinglets-repo") // Consistent directory for the entire repo.
+	targetDir := filepath.Join(zingHome, "zinglets", zingletName) // Consistent directory for the specific zinglet.
 
 	if _, err := os.Stat(targetDir); os.IsNotExist(err) {
-		// Clone the repository
-		fmt.Printf("Cloning zinglets repository from %s to %s\n", repoURL, targetDir)
+		// Clone the specific zinglet
+		fmt.Printf("Cloning zinglet from %s to %s\n", repoURL, targetDir)
 		cmd := exec.Command("git", "clone", repoURL, targetDir)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		return cmd.Run()
 	} else {
-		// Update the repository (assuming it's already cloned)
-		fmt.Printf("Updating zinglets repository in %s\n", targetDir)
+		// Update the specific zinglet (assuming it's already cloned)
+		fmt.Printf("Updating zinglet in %s\n", targetDir)
 		cmd := exec.Command("git", "-C", targetDir, "pull")
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr


### PR DESCRIPTION
Update zinglet installation to avoid pulling the entire repository.

* **zing/config.go**
  - Add `GetZingletURL` function to return the URL for a specific zinglet.
  - Use `fmt.Sprintf` to construct the URL for the specific zinglet.

* **zing/install.go**
  - Update `Install` function to call `CloneOrUpdateZinglet` instead of `CloneOrUpdate`.
  - Update `zingletDir` to point to the specific zinglet directory.

* **zing/repository.go**
  - Rename `CloneOrUpdate` to `CloneOrUpdateZinglet`.
  - Update `CloneOrUpdateZinglet` to clone or update only the specific zinglet directory.
  - Use `GetZingletURL` to get the URL for the specific zinglet.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SharkStudiosSK/zingpackage/pull/1?shareId=64035532-73d6-4123-aa2b-9a90dce26976).